### PR TITLE
Add new-cap rule exception for ember config

### DIFF
--- a/config/ember.js
+++ b/config/ember.js
@@ -2,5 +2,8 @@ module.exports = {
   extends: require.resolve('./base.js'),
   env: {
     'browser': true
+  },
+  rules: {
+    'new-cap': [ 'error', { 'capIsNewExceptions': [ 'A' ] } ]
   }
 };


### PR DESCRIPTION
This PR overwrites the `new-cap` eslint rule in the `config/ember.js` file to make an exception for the `Ember.A` method, which is typically used in an ember application.