### PR TITLE
Specify the node version we require

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,9 @@
     "type": "git",
     "url": "git+ssh://git@github.com/PatentNavigation/eslint-plugin-turbopatent.git"
   },
+  "engines": {
+    "node": ">= 6.9.0"
+  },
   "keywords": [
     "eslint",
     "eslint-plugin",


### PR DESCRIPTION
This plugin isn't meant for older node versions, and itself is not compatibly with <6, so specify 6.9.0 (the LTS version) as the minimum