### PR TITLE
disallow early use of let/const bound variables

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -44,6 +44,7 @@ module.exports = {
     'no-trailing-spaces': 'error',
     'no-unneeded-ternary': 'error',
     'no-unused-vars': [ 'error', { vars: 'all', args: 'none' } ],
+    'no-use-before-define': [ 'error', { 'functions': false } ],
     'no-var': 'error',
     'no-whitespace-before-property': 'error',
     'object-curly-spacing': [ 'error', 'always' ],


### PR DESCRIPTION
Disallow Early Use (no-use-before-define)

In ES6, block-level bindings (let and const) introduce a “temporal dead zone” where a ReferenceError will be thrown with any attempt to access the variable before its declaration.

Rule Details
This rule will warn when it encounters a reference to an identifier that has not yet been declared.