### PR TITLE
permit late class definition

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -44,7 +44,7 @@ module.exports = {
     'no-trailing-spaces': 'error',
     'no-unneeded-ternary': 'error',
     'no-unused-vars': [ 'error', { vars: 'all', args: 'none' } ],
-    'no-use-before-define': [ 'error', { 'functions': false } ],
+    'no-use-before-define': [ 'error', { 'functions': false, 'classes': false } ],
     'no-var': 'error',
     'no-whitespace-before-property': 'error',
     'object-curly-spacing': [ 'error', 'always' ],


### PR DESCRIPTION
Should have spent some more time testing this change. It's common (at least in the node libs) to define a helper class at the bottom of a file.