### PR TITLE
require semicolons

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -56,6 +56,7 @@ module.exports = {
     'quotes': 'off',
     'radix': 'error',
     'rest-spread-spacing': 'error',
+    'semi': [ 'error', 'always' ],
     'space-before-function-paren': [ 'error', 'never' ],
     'space-in-parens': 'error',
     'space-infix-ops': 'error',


### PR DESCRIPTION
I'm not sure what changed, but the latest eslint configuration doesn't seem to require semi-colons.