### PR TITLE
Update ESLint & eslint-plugin-ember release versions

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -67,6 +67,7 @@ module.exports = {
     'ember/closure-actions': 'error',
     'ember/jquery-ember-run': 'error',
     'ember/local-modules': 'error',
+    'ember/new-module-imports': 'error',
     'ember/no-empty-attrs': 'error',
     'ember/no-function-prototype-extensions': 'error',
     'ember/no-on-calls-in-components': 'error',

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   },
   "homepage": "https://github.com/PatentNavigation/eslint-plugin-turbopatent#readme",
   "devDependencies": {
-    "eslint": "^3.14.1",
+    "eslint": "^4.7.1",
     "git-release": "^0.6.0",
     "minimist": "^1.2.0"
   },
   "dependencies": {
-    "eslint-plugin-ember": "^3.1.2",
+    "eslint-plugin-ember": "^4.5.0",
     "requireindex": "^1.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
This PR also enables the "new-module-imports" rule from `eslint-plugin-ember`.