### PR TITLE
Update `eslint-plugin-ember` release number

### DIFF
--- a/config/ember.js
+++ b/config/ember.js
@@ -11,11 +11,6 @@ module.exports = {
     'no-console': [ 'error', { 'allow': [ 'warn', 'error' ] } ],
 
     // Custom rules
-    'ember/no-empty-attrs': 'error',
-    // We actually do not want to turn this rule off. However,
-    // the current rule has a bug. This rule does not take into
-    // account the new module import syntax. Until this is fixed,
-    // this rule should be turned off.
-    'ember/no-global-jquery': 'off'
+    'ember/no-empty-attrs': 'error'
   }
 };

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "minimist": "^1.2.0"
   },
   "dependencies": {
-    "eslint-plugin-ember": "^5.0.1",
+    "eslint-plugin-ember": "^5.0.2",
     "eslint-plugin-no-only-tests": "^2.0.0",
     "requireindex": "^1.1.0"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -262,9 +262,9 @@ escape-string-regexp@^1.0.0, escape-string-regexp@^1.0.2, escape-string-regexp@^
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
-eslint-plugin-ember@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-5.0.1.tgz#bd4b20e137b01530b709d87feb8428bbd68eb096"
+eslint-plugin-ember@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-5.0.2.tgz#6b6cb50465173b67e82f7703458fd166c6953ba4"
   dependencies:
     ember-rfc176-data "^0.2.7"
     require-folder-tree "^1.4.5"


### PR DESCRIPTION
There was a bug with the `ember/no-global-jquery` rule where it was reporting false
ESLint errors in applications that are using the new modules import syntax when
importing the jQuery module.