### PR TITLE
Fix no-only-tests rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "eslint-plugin-ember": "^5.0.2",
-    "eslint-plugin-no-only-tests": "^2.0.0",
+    "eslint-plugin-no-only-tests": "git+ssh://git@github.com/bendemboski/eslint-plugin-no-only-tests.git#6fde3db7cb547c600a12abbf486f3bee3a49fcf2",
     "requireindex": "^1.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,9 +270,9 @@ eslint-plugin-ember@^5.0.2:
     require-folder-tree "^1.4.5"
     snake-case "^2.1.0"
 
-eslint-plugin-no-only-tests@^2.0.0:
+"eslint-plugin-no-only-tests@git+ssh://git@github.com/bendemboski/eslint-plugin-no-only-tests.git#6fde3db7cb547c600a12abbf486f3bee3a49fcf2":
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.0.0.tgz#c76c29e973bb76f24c14e20fa87f1ff1f0c18d5f"
+  resolved "git+ssh://git@github.com/bendemboski/eslint-plugin-no-only-tests.git#6fde3db7cb547c600a12abbf486f3bee3a49fcf2"
 
 eslint-scope@^3.7.1:
   version "3.7.1"


### PR DESCRIPTION
There is a bug in the plugin that causes it to crash if a hash has a key named `only`, so switch to a fork with a [fix](https://github.com/levibuzolic/eslint-plugin-no-only-tests/pull/7).