### PR TITLE
Update to latest eslint-plugin-no-only-tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "eslint-plugin-ember": "^5.0.2",
-    "eslint-plugin-no-only-tests": "https://github.com/bendemboski/eslint-plugin-no-only-tests.git#6fde3db7cb547c600a12abbf486f3bee3a49fcf2",
+    "eslint-plugin-no-only-tests": "^2.0.1",
     "requireindex": "^1.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -355,9 +355,9 @@ eslint-plugin-ember@^5.0.2:
     require-folder-tree "^1.4.5"
     snake-case "^2.1.0"
 
-"eslint-plugin-no-only-tests@https://github.com/bendemboski/eslint-plugin-no-only-tests.git#6fde3db7cb547c600a12abbf486f3bee3a49fcf2":
-  version "2.0.0"
-  resolved "https://github.com/bendemboski/eslint-plugin-no-only-tests.git#6fde3db7cb547c600a12abbf486f3bee3a49fcf2"
+eslint-plugin-no-only-tests@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.0.1.tgz#c7bfa82a46be791f9625d720e990632b5dec3c7d"
 
 eslint-scope@^3.7.1:
   version "3.7.1"


### PR DESCRIPTION
The fix was finally merged so we can switch back off of our fork