### PR TITLE
Update no-console rule

### DIFF
--- a/config/ember.js
+++ b/config/ember.js
@@ -7,6 +7,7 @@ module.exports = {
     require.resolve('./base.js')
   ],
   rules: {
+    'no-console': [ "error", { allow: [ "warn", "error" ] } ],
     'ember/no-empty-attrs': 'error'
   },
   overrides: [


### PR DESCRIPTION
Ember is deprecating Ember.Logger and we should be using the console methods, so allow console.warn and console.log.