### PR TITLE
Fix CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     working_directory: ~/eslint-plugin-turbopatent
     docker:
-      - image: circleci/node:6-stretch
+      - image: circleci/node:12-stretch
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Update node to newer than 6, which is no longer supported by eslint-plugin-ember