### PR TITLE
Ignore rest siblings in no-unused-vars

### DIFF
--- a/config/base.js
+++ b/config/base.js
@@ -37,7 +37,7 @@ module.exports = {
     'no-throw-literal': 'error',
     'no-trailing-spaces': 'error',
     'no-unneeded-ternary': 'error',
-    'no-unused-vars': [ 'error', { vars: 'all', args: 'none' } ],
+    'no-unused-vars': [ 'error', { vars: 'all', args: 'none', ignoreRestSiblings: true } ],
     'no-use-before-define': [ 'error', { 'functions': false, 'classes': false } ],
     'no-var': 'error',
     'no-whitespace-before-property': 'error',


### PR DESCRIPTION
This allows constructs like `let { foo, ...allButFoo } = someObject` where `foo` isn't used for anything, just excluded from the `allButFoo` assignment, without it causing the no-unused-vars lint rule to error.